### PR TITLE
Firefox / Chrome Diff

### DIFF
--- a/chrome/mainChat/chat.css
+++ b/chrome/mainChat/chat.css
@@ -182,7 +182,7 @@
 	font-weight: bold;
 	margin-bottom: 5px;
 	cursor: pointer;
-  }
+	}
   .chatMessage.no_avatars .msg_user {
     margin-left: 8px!important
   }
@@ -325,6 +325,7 @@
 		}
 
 /* System Messages */
+
 	.chatMessage.systemPoster .msg_user {
 	  visibility: hidden
 	}
@@ -348,10 +349,6 @@
   .mentionsUser {
     background-color: #e9ff32!important
   }
-
-	.mentionedInChat .bubble {
-		box-shadow: 3px 3px 10px rgba(0,0,0,0.3);
-	}
 	
 	.chatMention {
 		font-weight: bold;

--- a/chrome/mainChat/chat.js
+++ b/chrome/mainChat/chat.js
@@ -7,7 +7,7 @@ if (
   var config = document.createElement("config");
   config.setAttribute("id", "habitRPGChatConfig");
   config.setAttribute("style", "display: none;");
-  chrome.storage.sync.get(
+  browser.storage.local.get(
     {
       uuid: "",
       api: "",
@@ -51,7 +51,7 @@ if (
 
   // Call markdown to html script
   var s = document.createElement("script");
-  s.src = chrome.extension.getURL("resources/habitica-markdown.js");
+  s.src = browser.extension.getURL("resources/habitica-markdown.js");
   s.onload = function() {
     this.parentNode.removeChild(this);
   };
@@ -67,7 +67,7 @@ if (
 
   // Call other functions
   var s = document.createElement("script");
-  s.src = chrome.extension.getURL("resources/miscFunctions.js");
+  s.src = browser.extension.getURL("resources/miscFunctions.js");
   s.onload = function() {
     this.parentNode.removeChild(this);
   };
@@ -75,7 +75,7 @@ if (
 
   // Load Purify.js to sanitize inputs
   var s = document.createElement("script");
-  s.src = chrome.extension.getURL("resources/purify.js");
+  s.src = browser.extension.getURL("resources/purify.js");
   s.onload = function() {
     this.parentNode.removeChild(this);
   };
@@ -85,7 +85,7 @@ if (
   //pause 2 seconds to allow everything to catch up
   setTimeout(function() {
     var s = document.createElement("script");
-    s.src = chrome.extension.getURL("mainChat/chat_inPage.js");
+    s.src = browser.extension.getURL("mainChat/chat_inPage.js");
     s.onload = function() {
       this.parentNode.removeChild(this);
     };
@@ -109,7 +109,7 @@ if (
       return;
     }
 
-    chrome.storage.sync.set(
+    browser.storage.local.set(
       {
         uuid: message.uuid,
         api: message.apik

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -4,16 +4,20 @@
   "short_name": "Habit Chat",
   "description": "This extension adds a Habitica chat client to habitica.com",
   "version": "2.2.8",
-  "options_page": "optionsPage/options.html",
   "icons": {
     "16": "images/icon16.png",
     "48": "images/icon48.png",
     "128": "images/icon128.png"
   },
   "browser_action": {
-    "default_icon": "images/icon128.png",
+    "browser_style": true,
+    "default_icon": {
+      "16": "images/icon16.png",
+      "48": "images/icon48.png",
+      "128": "images/icon128.png"
+    },
     "default_popup": "optionsPage/options.html",
-    "name": "Habitica Chat Extension"
+    "default_title": "Habitica Chat Extension"
   },
   "content_scripts": [
     {
@@ -23,9 +27,6 @@
       "exclude_matches": ["*://*.habitica.com/static/*"]
     }
   ],
-  "externally_connectable": {
-    "matches": ["*://*.habitica.com/*"]
-  },
   "web_accessible_resources": [
     "mainChat/chat.css",
     "mainChat/chat_inPage.js",

--- a/chrome/optionsPage/options.css
+++ b/chrome/optionsPage/options.css
@@ -30,7 +30,13 @@ body {
 #setupButton {
  text-align: center; 
 }
+
+#textInputs, #warning, #manualSetupTriggerHolder {
+  text-align: center;
+}
+
 #checkBoxes {
+  text-align: center;
  	margin-top: 20px;
 }
 
@@ -69,12 +75,17 @@ body {
  display: none;
 }
 
+#userForm .row, #userForm .field, #userForm .legend {
+  text-align: center;
+}
+
 #userForm {
   margin-top: 30px;
- display: none; 
+  display: none; 
 }
 
 #gitHubButton, #reportBugButton, #wikiButton {
+  text-align: center;
   margin-top: 10px;
   width: 100%;
 }

--- a/chrome/optionsPage/options.html
+++ b/chrome/optionsPage/options.html
@@ -36,6 +36,7 @@
     </div>
     <br>
     <br>
+    <br>
     <div id="textInputs">
       <label>Message count limit: <input id="messageCount" type="number" min="1" max="200"></label>/200<br>
       <label>Pause chat after <input id="timeoutAfter" type="number" min="15" max="240">/240 minutes of inactivity</label>
@@ -66,7 +67,7 @@
 				<div class="legend">User ID </div><div class="field"><input type="text" id="uuid" /></div>
 			</div>
 			<div class="row">
-				<div class="legend">API Key    </div><div class="field"><input type="text" id="api" /> </div>
+				<div class="legend">API Key </div><div class="field"><input type="text" id="api" /> </div>
 			</div>
 		</div>
 		<div id="status">Saved...</div>

--- a/chrome/optionsPage/options.js
+++ b/chrome/optionsPage/options.js
@@ -1,4 +1,4 @@
-// Saves options to chrome.storage
+// Saves options to browser.storage
 function save_options() {
   var uuid = document.getElementById('uuid').value;
   var api = document.getElementById('api').value;
@@ -20,7 +20,7 @@ function save_options() {
   if (timeoutAfter < 15) {
     timeoutAfter = 15;
   }
-  chrome.storage.sync.set({
+  browser.storage.local.set({
     uuid: uuid,
     api: api,
     enableSound: enableSound,
@@ -46,9 +46,9 @@ function save_options() {
 }
 
 // Restores select box and checkbox state using the preferences
-// stored in chrome.storage.
+// stored in browser.storage.
 function restore_options() {
-  chrome.storage.sync.get({
+  browser.storage.local.get({
     uuid: '',
     api: '',
     enableSound: true,
@@ -82,19 +82,19 @@ function restore_options() {
 }
 
 function openSettings() {
-	chrome.tabs.create({ url: "https://habitica.com/user/settings/api" });
+	browser.tabs.create({ url: "https://habitica.com/user/settings/api" });
 }
 
 function openGitHub() {
-	chrome.tabs.create({ url: "https://github.com/HabitRPG/habitica-chat-extension" });
+	browser.tabs.create({ url: "https://github.com/HabitRPG/habitica-chat-extension" });
 }
 
 function openWiki() {
-	chrome.tabs.create({ url: "https://habitica.fandom.com/wiki/Chat_Extension" });
+	browser.tabs.create({ url: "https://habitica.fandom.com/wiki/Chat_Extension" });
 }
 
 function reportBug() {
-	chrome.tabs.create({ url: "https://habitica.com/groups/guild/a29da26b-37de-4a71-b0c6-48e72a900dac" });
+	browser.tabs.create({ url: "https://habitica.com/groups/guild/a29da26b-37de-4a71-b0c6-48e72a900dac" });
 }
 
 function displayManualOptions() {


### PR DESCRIPTION
# Don't merge
The purpose of this pull request is only to illustrate the differences between the Firefox implementation and the Chrome implementation so is clear what the #71 pull request is doing.

The changes generated here were achieved by replacing the files on the `chrome` folder with the files on `firefox` folder.

Theses are the differences and changes:
- `chrome/mainChat/chat.css` > Two spacing issues and one extra rule. On the other pull request this rule was kept for both browsers
- `chrome/mainChat/chat.js` > The namespace used to call extension specific code is different for Chrome and Firefox, [but Firefox is also compatible with the chrome namespace](https://extensionworkshop.com/documentation/develop/porting-a-google-chrome-extension/). Another difference is that for chrome, the `sync` storage was used instead of `local`, but for some reason when I was testing the code on Firefox, calling the sync storage always returned and empty object. I think this may be caused by different implementations (e.g. how it is handles the case when the user don't have an account linked to the browser) but changing it to the `local` storage works for both browsers
- `chrome/manifest.json` > The chrome manifest had an option page with the non-standard `options_page` key name. This was changed to `"options_ui": { "page": "optionsPage/options.html" }` for both browsers. The `browser_action` icon was changed to an object containing the different size images for both browsers, and the `name` key renamed to `default_title`. The Chrome version had an extra option called `externally_connectable`, [used to specify which pages can connect to the runtime and send messages](https://developer.chrome.com/extensions/messaging#external-webpage), but this functionality is not used on the extension so it was removed
- `chrome/optionsPage/options.css` > One spacing issue and some extra rules on the Firefox css. All the rules were kept for both browsers 
- `chrome/optionsPage/options.html` > An extra `<br>` and some spaces. The Firefox version was kept
- `chrome/optionsPage/options.js` > Same as `chrome/mainChat/chat.js`. Namespace and `sync` -> `local`