### PR TITLE
Remove activeTab permission request

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -38,5 +38,5 @@
     "resources/jquery.js",
     "resources/purify.js"
   ],
-  "permissions": ["storage", "activeTab"]
+  "permissions": ["storage"]
 }


### PR DESCRIPTION
We received this notice from the Chrome Web Store:

![image](https://user-images.githubusercontent.com/4501321/176967346-d71a0f5b-bf8b-4f3e-976c-5bc1b7729ddd.png)

On a search, the critique looks accurate--while we use `storage` in various places, the only place `activeTab` appears is in the manifest.json. This PR removes the permission request from the manifest.